### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # Cloudinary MCP Server
 
+<a href="https://glama.ai/mcp/servers/@yoavniran/cloudinary-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yoavniran/cloudinary-mcp-server/badge" alt="cloudinary-mcp-server MCP server" />
+</a>
+
 <p align="center">
     <a href="https://badge.fury.io/js/cloudinary-mcp-server">
         <img src="https://badge.fury.io/js/cloudinary-mcp-server.svg" alt="npm version" height="20">


### PR DESCRIPTION
This PR adds a badge for the [cloudinary-mcp-server](https://glama.ai/mcp/servers/@yoavniran/cloudinary-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@yoavniran/cloudinary-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yoavniran/cloudinary-mcp-server/badge" alt="cloudinary-mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.